### PR TITLE
Flexible JPA Updates

### DIFF
--- a/core/src/main/java/org/keycloak/representations/idm/FilterAttributeRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/FilterAttributeRepresentation.java
@@ -1,0 +1,33 @@
+package org.keycloak.representations.idm;
+
+import java.util.List;
+
+public class FilterAttributeRepresentation {
+  private String key;
+  private List<String> values;
+  private Boolean exact;
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public void setValues(List<String> values) {
+    this.values = values;
+  }
+
+  public Boolean getExact() {
+    return exact;
+  }
+
+  public void setExact(Boolean exact) {
+    this.exact = exact;
+  }
+}

--- a/core/src/main/java/org/keycloak/representations/idm/UserRoleRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserRoleRepresentation.java
@@ -1,0 +1,25 @@
+package org.keycloak.representations.idm;
+
+import java.util.List;
+import java.util.Map;
+
+public class UserRoleRepresentation extends UserRepresentation {
+    private Map<String, List<RoleRepresentation>> roles;
+
+    public UserRoleRepresentation(UserRepresentation rep) {
+        super(rep);
+    }
+
+    public UserRoleRepresentation(UserRepresentation rep, Map<String, List<RoleRepresentation>> roles) {
+        super(rep);
+        this.roles = roles;
+    }
+
+    public Map<String, List<RoleRepresentation>> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Map<String, List<RoleRepresentation>> roles) {
+        this.roles = roles;
+    }
+}

--- a/core/src/main/java/org/keycloak/representations/idm/UserRolesBodyRepresentation.java
+++ b/core/src/main/java/org/keycloak/representations/idm/UserRolesBodyRepresentation.java
@@ -1,0 +1,86 @@
+package org.keycloak.representations.idm;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+
+public class UserRolesBodyRepresentation {
+  private String clientId;
+  private String orgId;
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private List<FilterAttributeRepresentation> filterAttributes = Collections.emptyList();
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private Set<String> byRoles = new HashSet<>();
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private List<String> sortBy = new ArrayList<>(Collections.singleton("username"));
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private Integer first = 0;
+
+  @JsonSetter(nulls = Nulls.SKIP)
+  private Integer max = 10;
+
+  public Integer getMax() {
+    return max;
+  }
+
+  public void setMax(Integer max) {
+    this.max = max;
+  }
+
+  public Integer getFirst() {
+    return first;
+  }
+
+  public void setFirst(Integer first) {
+    this.first = first;
+  }
+
+  public List<String> getSortBy() {
+    return sortBy;
+  }
+
+  public void setSortBy(List<String> sortBy) {
+    this.sortBy = sortBy;
+  }
+
+  public Set<String> getByRoles() {
+    return byRoles;
+  }
+
+  public void setByRoles(Set<String> byRoles) {
+    this.byRoles = byRoles;
+  }
+
+  public List<FilterAttributeRepresentation> getFilterAttributes() {
+    return filterAttributes;
+  }
+
+  public void setFilterAttributes(List<FilterAttributeRepresentation> filterAttributes) {
+    this.filterAttributes = filterAttributes;
+  }
+
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public void setClientId(String clientId) {
+    this.clientId = clientId;
+  }
+}

--- a/server-spi/src/main/java/org/keycloak/models/UserRoleModel.java
+++ b/server-spi/src/main/java/org/keycloak/models/UserRoleModel.java
@@ -1,0 +1,26 @@
+package org.keycloak.models;
+
+import java.util.List;
+import java.util.Map;
+
+public class UserRoleModel {
+    private UserModel user;
+
+    public UserModel getUser() {
+        return user;
+    }
+
+    private Map<String, List<RoleModel>> roles;
+
+    public Map<String, List<RoleModel>> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Map<String, List<RoleModel>> roles) {
+        this.roles = roles;
+    }
+
+    public UserRoleModel(UserModel user) {
+        this.user = user;
+    }
+}


### PR DESCRIPTION
- Added support for more granular control in JpaUserProvider to allow filtering by id, different sorting by desc and asc, including client roles, and filtering through organization id.
- Added support for more granular filtering was added, allowing filtering by multiple values for 1 key at a time.